### PR TITLE
fix 'redis-server: command not found'

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,7 @@ set -u
 
 source $OPENSHIFT_CARTRIDGE_SDK_BASH
 
-version=${REDIS_BRANCH:-2.8}
+version=${REDIS_BRANCH:-3.0}
 
 for dir in logs pid tmp env; do
 	mkdir -p $dir

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,7 +1,7 @@
 Name: redis
 Cartridge-Short-Name: REDIS
 Display-Name: Redis
-Version: "2.8"
+Version: "3.0"
 Website: https://github.com/gerardogc2378/openshift-redis-cart
 Cartridge-Version: 0.1.0
 Cartridge-Vendor: gerardogc2378
@@ -10,7 +10,7 @@ Categories:
   - database
   - embedded
 Provides:
-  - redis-2.8
+  - redis-3.0
   - redis
 Scaling:
   Min: 1


### PR DESCRIPTION
Simple fix out-of-sync version numbers in files. Now installing fine with 3.0.